### PR TITLE
Add a section for practice tech tests

### DIFF
--- a/online-resources/tech-tests-and-interviews.md
+++ b/online-resources/tech-tests-and-interviews.md
@@ -12,10 +12,16 @@
 * [JS specific - The Definitive JavaScript Handbook for your next developer interview](https://medium.freecodecamp.org/the-definitive-javascript-handbook-for-a-developer-interview-44ffc6aeb54e)
 * [Learn about Scalability to use in System Design Interview - Harvard summer school lecture](https://www.youtube.com/watch?v=-W9F__D3oY4)
 
+### Practice
+
+* [CodeSignal](https://codesignal.com/)
+* [CodeWars](https://www.codewars.com/)
+* [freeCodeCamp](https://learn.freecodecamp.org/)
+* [HackerRank](https://www.hackerrank.com/)
+
 ## Tech CV
 
 * [Consider creating one on Github - here's an example](https://github.com/charlottebrf/CV)
 * [How to write a killer technical CV](https://medium.com/tech-ladies/how-to-ace-your-next-technical-interview-with-katie-thomas-self-taught-software-engineer-at-google-2448d71bd5e7)
 * [Screening technical CVs](https://medium.com/@stevebennett/screening-technical-cvs-7ed4b843469a)
-
 


### PR DESCRIPTION
CodeSignal & freeCodeCamp both have sections explicitly directed towards practising technical tests for tech interviews.