### PR TITLE
Add a few more Germany based workshop/teaching spaces in cities

### DIFF
--- a/meetups/d-a-ch/meetups.md
+++ b/meetups/d-a-ch/meetups.md
@@ -14,6 +14,23 @@
 * [Codebar](https://codebar.io/berlin)
   * Free regular programming workshops trying to bridge the diversity gap in tech
 
+* [Women Techmakers Berlin](http://wtmberlin.com/)
+  * WTM Berlin run a series of 6-8 week long study jams ranging from Android, iOS to JavaScript. 
+  * They also run regular events and meetups
+
+* [CSS Classes](https://cssclass.es/)
+  * Combined Workshop/Hackathon one-day event that is hosted regularly to teach beginners and experts alike on CSS best practices
+
+### Hamburg
+
+* [CSS Classes](https://cssclass.es/)
+  * Combined Workshop/Hackathon one-day event that is hosted regularly to teach beginners and experts alike on CSS best practices
+
+### Koeln
+
+* [f.u.c.k. Cologne](https://twitter.com/fuck_cologne)
+  * Women and LGBTI friendly Meetup that is centered around computers, technology and learning
+
 ### Leipzig
 
 * [Code Girls](https://codegirls.de/)


### PR DESCRIPTION
Added a few more German based meetups - most importantly Women Techmakers Berlin who run really cool workshops for free!

I think they have other chapters in other European cities too, but I need to check!

I tried to only add those where you can go and learn/study (rather than talk-based), as I explained in an issue I raised!