### PR TITLE
Add online resources, Berlin based meetups and small formatting changes

### DIFF
--- a/bootcamps/Israel/bootcamps.md
+++ b/bootcamps/Israel/bootcamps.md
@@ -2,7 +2,7 @@
 
 ## Nazareth
 
-* [Founders & Coders](https://foundersandcoders.com/):
+* [Founders & Coders](https://foundersandcoders.com/)
     * 16 week bootcamp
     * Fullstack Node & JavaScript, Engineering project
     * Hiring Partners & opportunity to volunteer afterwards to 'pay it forwards'

--- a/bootcamps/Israel/bootcamps.md
+++ b/bootcamps/Israel/bootcamps.md
@@ -1,5 +1,4 @@
-#Bootcamps
-
+# Bootcamps
 
 ## Nazareth
 

--- a/bootcamps/d-a-ch/bootcamps.md
+++ b/bootcamps/d-a-ch/bootcamps.md
@@ -1,5 +1,4 @@
-#Bootcamps
-
+# Bootcamps
 
 ## Berlin
 

--- a/bootcamps/uk/bootcamps.md
+++ b/bootcamps/uk/bootcamps.md
@@ -1,16 +1,15 @@
-#Bootcamps
-
+# Bootcamps
 
 ## London 
 
-* [Founders & Coders](https://foundersandcoders.com/):
+* [Founders & Coders](https://foundersandcoders.com/)
     * 16 week bootcamp
     * Fullstack Node & JavaScript, Engineering project
     * Hiring Partners & opportunity to volunteer afterwards to 'pay it forwards'
     * See the Open Source curriculum [here](https://github.com/foundersandcoders/info/blob/master/curriculum.md)
     
 
-* [Code First Girls](https://www.codefirstgirls.org.uk/):
+* [Code First Girls](https://www.codefirstgirls.org.uk/)
     * 16 week bootcamp 
     * Web development (CSS, HTML, JavaScript, UX, UI), Programming in Python, Databases, Testing/Test driven development, Agile* and the basics of Cybersecurity. 
     * Digital Intensive Program in partnership with BT technology teams

--- a/meetups/d-a-ch/meetups.md
+++ b/meetups/d-a-ch/meetups.md
@@ -21,6 +21,13 @@
 * [CSS Classes](https://cssclass.es/)
   * Combined Workshop/Hackathon one-day event that is hosted regularly to teach beginners and experts alike on CSS best practices
 
+* [Rails Girls Berlin](http://railsgirlsberlin.de/)  
+  * Whole day workshop providing an introduction to Ruby on Rails
+
+* [Berlin JS](https://berlinjs.org/)  
+  * Monthly JS-focused meetup with sessions usually comprising of a series of longer talks and lightning talks
+
+
 ### Hamburg
 
 * [CSS Classes](https://cssclass.es/)

--- a/online-resources/free-ebooks.md
+++ b/online-resources/free-ebooks.md
@@ -13,7 +13,6 @@
 ## Python
 * [Learn Python the Hard Way](https://learnpythonthehardway.org/python3/)
 * [Pieter Spronck. The Coder’s Apprentice: Learning Programming with Python 3, 2017.](http://www.spronck.net/pythonbook/)
-* [Pieter Spronck. The Coder’s Apprentice: Learning Programming with Python 3, 2017.](http://www.spronck.net/pythonbook/)
 
 ## Ruby
 * [Learn Ruby the Hard Way](https://learnrubythehardway.org/book/)

--- a/online-resources/free-ebooks.md
+++ b/online-resources/free-ebooks.md
@@ -11,8 +11,8 @@
 * [Professor Frisby's Mostly Adequate Guide to Functional Programming](https://mostly-adequate.gitbooks.io/mostly-adequate-guide/) by Brian Lonsdorf
 
 ## Python
-* [Learn Python the Hard Way](https://learnpythonthehardway.org/python3/)
-* [Pieter Spronck. The Coder’s Apprentice: Learning Programming with Python 3, 2017.](http://www.spronck.net/pythonbook/)
+* [Learn Python the Hard Way](https://learnpythonthehardway.org/python3/) by Zed A. Shaw
+* [The Coder’s Apprentice: Learning Programming with Python 3, 2017.](http://www.spronck.net/pythonbook/) by Pieter Spronck
 
 ## Ruby
-* [Learn Ruby the Hard Way](https://learnrubythehardway.org/book/)
+* [Learn Ruby the Hard Way](https://learnrubythehardway.org/book/) by Zed A. Shaw

--- a/online-resources/free-ebooks.md
+++ b/online-resources/free-ebooks.md
@@ -8,9 +8,11 @@
 * [JavaScript Enlightenment](http://javascriptenlightenment.com/) by Cody Lindley
 * [DOM Enlightenment](http://domenlightenment.com/) by Cody Lindley
 * [Front-End Developers Handbook](https://frontendmasters.com/books/front-end-handbook/2018/) by Cody Lindley
+* [Professor Frisby's Mostly Adequate Guide to Functional Programming](https://mostly-adequate.gitbooks.io/mostly-adequate-guide/) by Brian Lonsdorf
 
 ## Python
 * [Learn Python the Hard Way](https://learnpythonthehardway.org/python3/)
+* [Pieter Spronck. The Coder’s Apprentice: Learning Programming with Python 3, 2017.](http://www.spronck.net/pythonbook/)
 * [Pieter Spronck. The Coder’s Apprentice: Learning Programming with Python 3, 2017.](http://www.spronck.net/pythonbook/)
 
 ## Ruby


### PR DESCRIPTION
Changes proposed:

- Formatted titles and headers in the Bootcamps section for consistency
- Added a functional programming resource to the E-book section
- Added missing author names in E-books section and ensured all entries adhere to the following format: '[resource name] by [author name]'
- Added two Berlin based meet-ups